### PR TITLE
Added loadExtension() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,22 @@ module.exports = function(filename, mode) {
 
 				statement = that.db.prepare.apply(that.db, args);
 			});
-		}
+		},
+		loadExtension: function() {
+			var that = this;
+			var args = Array.prototype.slice.call(arguments, 0);
+
+			return new Promise(function(resolve, reject) {
+				args.push(function(err) {
+					if (err) {
+						reject(err);
+					}
+					resolve(this);
+				});
+
+				that.db.loadExtension.apply(that.db, args);
+			})
+		},
 	};
 	Statement.prototype = {
 		bind: function() {


### PR DESCRIPTION
I needed the ability to load a custom extension in to SQLite so I've added a wrapper around the 'loadExtension()' function from the underlying 'sqlite3' package.

Created a PR because I thought perhaps others may find it useful as well. 